### PR TITLE
Reject 65536 as a port (valid range is 1..65535)

### DIFF
--- a/lib/iri.rb
+++ b/lib/iri.rb
@@ -259,7 +259,7 @@ class Iri
     val = Integer(val)
     raise(ArgumentError, "The port can't be negative") if val.negative?
     raise(ArgumentError, "The port can't be zero") if val.zero?
-    raise(ArgumentError, "The port can't be larger than 65536") if val > 65_536
+    raise(ArgumentError, "The port can't be larger than 65535") if val > 65_535
     modify(local: false) do |c|
       c.scheme ||= 'http'
       c.port = val

--- a/test/test_iri.rb
+++ b/test/test_iri.rb
@@ -202,6 +202,16 @@ class IriTest < Minitest::Test
     end
   end
 
+  def test_rejects_too_large_port
+    assert_raises(ArgumentError) do
+      Iri.new('http://google.com').port(65_536)
+    end
+  end
+
+  def test_accepts_highest_port
+    assert_equal('http://google.com:65535/', Iri.new('http://google.com/').port(65_535).to_s)
+  end
+
   def test_rejects_nil_path
     assert_raises(ArgumentError) do
       Iri.new('http://google.com').path(nil)


### PR DESCRIPTION
Closes #260.

The upper-bound guard in `port` used `val > 65_536`, so `65536` was accepted even though the valid TCP port range is `1..65535`. Changed the comparison and the error message to `65535`.

Before:

```ruby
Iri.new('http://x').port(65536).to_s  # => "http://x:65536"
```

Now it raises `ArgumentError`, and `65535` still works.

Added two tests: one for the rejected boundary and one confirming `65535` is still accepted.