### PR TITLE
fix: reject TCP port 65536 (off-by-one upper bound)

### DIFF
--- a/lib/iri.rb
+++ b/lib/iri.rb
@@ -259,7 +259,7 @@ class Iri
     val = Integer(val)
     raise(ArgumentError, "The port can't be negative") if val.negative?
     raise(ArgumentError, "The port can't be zero") if val.zero?
-    raise(ArgumentError, "The port can't be larger than 65536") if val > 65_536
+    raise(ArgumentError, "The port can't be larger than 65535") if val > 65_535
     modify(local: false) do |c|
       c.scheme ||= 'http'
       c.port = val

--- a/test/test_iri.rb
+++ b/test/test_iri.rb
@@ -255,4 +255,14 @@ class IriTest < Minitest::Test
   def test_without_alias_for_del
     assert_equal('http://google.com/?b=2', Iri.new('http://google.com/?a=1&b=2&c=3').without(:a, :c).to_s)
   end
+  def test_rejects_port_65536
+    assert_raises(ArgumentError) do
+      Iri.new('http://google.com').port(65_536)
+    end
+  end
+
+  def test_accepts_port_65535
+    assert_equal('http://google.com:65535/', Iri.new('http://google.com').port(65_535).to_s)
+  end
+
 end


### PR DESCRIPTION
## Summary

fix: reject TCP port 65536 (off-by-one upper bound)

## Changes

- Valid ports are 1..65535; reject val > 65535 instead of > 65536.
- Correct the error message to say 65535.
- Add tests for rejecting 65536 and accepting 65535.

Fixes #260
